### PR TITLE
[POC] make DIVESDK Cocoapods supported

### DIFF
--- a/DIVE-SDK-iOS.podspec
+++ b/DIVE-SDK-iOS.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+    s.name             = 'DIVE-SDK-iOS'
+    s.version          = '1.240307.2'
+    s.summary          = 'A short description of DIVE iOS SDK.'
+    s.homepage         = 'https://github.com/IDScanNet/DIVE-SDK-iOS'
+    s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
+    s.author           = { 'free felt' => 'eiros@me.com' }
+    s.source           = { :git => 'https://github.com/IDScanNet/DIVE-SDK-iOS', :tag => s.version.to_s }
+    s.ios.deployment_target = '12.0'
+    s.ios.vendored_frameworks = 'Libs/IDScanCapture.xcframework', 'Libs/IDScanPDFDetector.xcframework', 'Libs/IDScanMRZDetector.xcframework'
+    s.swift_version = '5.0'
+
+    s.subspec 'DIVESDK' do |ss|
+        ss.ios.deployment_target = '12.0'
+        ss.source_files = 'Sources/DIVESDKCommon/**/*', 'Sources/DIVESDK/**/*'
+    end
+
+    s.subspec 'DIVEOnlineSDK' do |ss|
+        ss.ios.deployment_target = '12.0'
+        ss.source_files = 'Sources/DIVESDKCommon/**/*', 'Sources/IDSCommonTools/**/*', 'Sources/IDSLocationManager/**/*', 'Sources/IDSSystemInfo/**/*', 'Sources/DIVEOnlineSDK/**/*'
+        ss.dependency 'KeychainSwift', '~> 21.0.0'
+    end
+
+  end


### PR DESCRIPTION
[POC] make DIVESDK Cocoapods supported

I am working with project with your sdk on project

I am happy to report that the SDK is working as expected. However, I did have to make quite modifications to the code especially DIVESDK itself to get it to work properly.

There are some outlines that I would like to mention
- iOS SDK did not capture any parameters and did not support additional parameters like the `verifyFace` option in `https://dvs2.idware.net/api/docs/index.html?urls.primaryName=V3`
- iOS SDK did not send userAgent or capture mode in the request
- SDK setup can be a challenging task, especially for complex projects. I would like to bring up for support "Cocoapods". This can make the setup process much easier

This changes are just POC how to make this DIVESDK Cocoapods supported

Thank you for your understanding